### PR TITLE
New Feature: Discrete Nuclear Level Cross-Section Tracking and Output in TALYS

### DIFF
--- a/source/A0_talys_mod.f90
+++ b/source/A0_talys_mod.f90
@@ -757,6 +757,7 @@ module A0_talys_mod
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia) :: chanexist    ! flag for existence of exclusive cross sect
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia) :: chanfisexist ! flag for existence of exclusive fission cr
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia,0:numlev) :: chanisoexist ! flag for existence of exclusive iso
+  logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia,0:numlev) :: chanlevexist ! flag for existence of discrete levels
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia) :: chanopen     ! flag to open channel with first non-zero c
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia) :: gamchanexist ! flag for existence of exclusive discrete g
   logical, dimension(0:numin,0:numip,0:numid,0:numit,0:numih,0:numia) :: recchanexist ! flag for existence of exclusive recoil spe
@@ -2085,6 +2086,7 @@ module A0_talys_mod
   real(sgl), dimension(0:numchantot)                     :: yieldchannel   ! relative yield
   real(sgl), dimension(0:numchantot, 0:numpar, 0:numen)  :: xschannelsp    ! channel cross section spectra
   real(sgl), dimension(0:numchantot,0:numex+1)           :: xsexcl         ! exclusive cross section per excitation energy
+  real(sgl), dimension(0:numchantot,0:numex+1)           :: xsdisclev      ! discrete level cross section per excitation energy
   real(sgl), dimension(0:numchantot)                     :: xsfischannel   ! fission channel cross section
   real(sgl), dimension(0:numchantot, 0:numpar, 0:numen)  :: xsfischannelsp ! fission channel spectrum
   real(sgl), dimension(0:numchantot)                     :: xsgamchannel   ! gamma channel cross section

--- a/source/channels.f90
+++ b/source/channels.f90
@@ -172,8 +172,10 @@ subroutine channels
 !
   if (flaginitpop) then
     xsexcl(0, maxex(0, 0) + 1) = xsinitpop
+    xsdisclev(0, maxex(0, 0) + 1) = xsinitpop
   else
     xsexcl(0, maxex(0, 0) + 1) = xsreacinc
+    xsdisclev(0, maxex(0, 0) + 1) = xsreacinc
   endif
   gamexcl(0, maxex(0, 0) + 1) = 0.
 !
@@ -259,6 +261,7 @@ subroutine channels
         Qexcl(0, 0) = S(0, 0, k0) + targetE
         do nexout = 0, numex + 1
           xsexcl(idnum, nexout) = 0.
+          xsdisclev(idnum, nexout) = 0.
           gamexcl(idnum, nexout) = 0.
         enddo
         if (flagspec) then
@@ -339,6 +342,7 @@ subroutine channels
             if (Zcomp == 0 .and. Ncomp == 0) then
               nex = maxex(Zcomp, Ncomp) + 1
               xsexcl(idnum, nexout) = xsexcl(idnum, nexout) + feedexcl(Zcomp, Ncomp, type, nex, nexout)
+              xsdisclev(idnum, nexout) = xsdisclev(idnum, nexout) + feedexcl(Zcomp, Ncomp, type, nex, nexout)
               if (type == 0) gamexcl(idnum, nexout) = gamexcl(idnum, nexout) + &
                 feedexcl(Zcomp, Ncomp, 0, nex, nexout)
               if (flagspec) then
@@ -359,6 +363,8 @@ subroutine channels
               if (type == 0) then
                 gamexcl(idnum, nexout) = gamexcl(idnum, nexout) + term2
                 if (nex <= Nlast(Zcomp, Ncomp, 0)) xsgamdischan(idnum, nex, nexout) = term2
+                else
+                  xsdisclev(idnum, nexout) = xsdisclev(idnum, nexout) + term2
               endif
                 gamexcl(idnum, nexout) = gamexcl(idnum, nexout) + term1 * gamexcl(idorg, nex)
 !   endif

--- a/source/channelsout.f90
+++ b/source/channelsout.f90
@@ -143,6 +143,7 @@ subroutine channelsout
   character(len=8)  :: spstring  ! string
   character(len=12)  :: Estr
   character(len=12) :: isofile   ! file with isomeric cross section
+  character(len=13) :: levfile   ! file with isomeric cross section
   character(len=12) :: gamfile   ! giant resonance parameter file
   character(len=16) :: xsfile    ! file with channel cross sections
   character(len=21) :: spfile    ! file with spectra
@@ -393,6 +394,42 @@ Loop2:    do in = 0, numin
               enddo
               exit
             endif
+          enddo
+!
+! B2. Discrete level cross sections
+!
+          NL = Nlast(Zcomp, Ncomp, 0)
+          do nex = 0, NL
+            levfile = 'dxs000000.L00'
+            write(levfile(4:9), '(6i1)') in, ip, id, it, ih, ia
+            write(levfile(12:13), '(i2.2)') levnum(Zcomp, Ncomp, nex)
+            if ( .not. chanlevexist(in, ip, id, it, ih, ia, nex)) then
+              chanlevexist(in, ip, id, it, ih, ia, nex) = .true.
+              open (unit = 1, file = levfile, status = 'unknown')
+              topline=trim(targetnuclide)//trim(reaction)//trim(finalnuclide)//' '//trim(quantity)
+              Ncol=2
+              MF = 10
+              call write_header(topline,source,user,date,oformat)
+              call write_target
+              call write_reaction(reaction,Qexcl(idc, nex),Ethrexcl(idc, nex),MF,MT)
+              call write_residual(Z,A,finalnuclide)
+              call write_level(2,kiso,levnum(Zcomp, Ncomp, nex),edis(Zcomp, Ncomp, nex), &
+ &              jdis(Zcomp, Ncomp, nex),parlev(Zcomp, Ncomp, nex),tau(Zcomp, Ncomp, nex))
+              call write_quantity(quantity)
+              call write_datablock(Ncol,Ninc,col,un)
+              do nen = 1, Ninclow
+                write(1, '(3es15.6)') eninc(nen), fxschaniso(nen, idc, nex)
+                  fxschaniso(nen, idc, nex) = 0.
+                  fexclbranch(nen, idc, nex) = 0.
+              enddo
+              do nen = Ninclow + 1, nin - 1
+                write(1, '(3es15.6)') eninc(nen), 0.
+              enddo
+            else
+              open (unit = 1, file = levfile, status = 'old', position = 'append')
+            endif
+            write(1, '(3es15.6)') Einc, xsdisclev(idc, nex)
+            close (unit = 1)
           enddo
 !
 ! C. Discrete gamma-rays


### PR DESCRIPTION
## New Feature: Discrete Nuclear Level Cross-Section Tracking and Output in TALYS

### Problem

TALYS lacked the ability to track and report cross-sections for individual nuclear levels. Discrete level contributions were aggregated with continuum cross-sections in the general exclusive array (`xsexcl`), making it impossible to isolate the population cross-section for any specific level.

---

### Solution

This PR introduces dedicated infrastructure to track, accumulate, and output discrete level cross-sections separately from continuum contributions.

---

### Changes

**New array infrastructure**
Two new arrays support the separation of discrete level data:
- `chanlevexist` — a flag array indicating whether a discrete level cross-section exists for a given reaction channel and level
- `xsdisclev` — dedicated storage for discrete level cross-sections, decoupled from the general exclusive array

**Cross-section accumulation logic (`channels.f90`)**
Gamma-ray contributions are already directed to `gamexcl`, and now individual level cross-sections directed to `xsdisclev`. This separation does not introduce any double-counting and preserves accurate accounting per reaction pathway.

**Dedicated output files (`channelsout.f90`)**
A new output routine writes individual files for each populated discrete level, following the naming convention:

```
dxs[6-digit channel].L[2-digit level]
```
*Example:* `dxs100000.L05` for a channel populating level 5.

Each file includes ENDF-formatted headers with level metadata (excitation energy, spin, parity, lifetime) and the cross-section as a function of incident neutron energy. Output is generated for all populated discrete levels up to max `numlev` set , or the maximum available level for the isotope.

---

### Impact

- Enables extraction of population cross-sections for individual discrete nuclear levels
- No change to existing continuum cross-section behavior
- Output files are directly compatible with ENDF formatting conventions